### PR TITLE
feature: add action in main

### DIFF
--- a/.github/workflows/conventional_branch.yml
+++ b/.github/workflows/conventional_branch.yml
@@ -1,0 +1,23 @@
+name: "Branch Naming Convention"
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+      - master
+    types: [opened, synchronize, reopened]
+
+jobs:
+  enforce-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: deepakputhraya/action-branch-name@master
+        with:
+          regex: '^(feature|bugfix|chore)\/[a-z0-9\-]+$|^(hotfix\/[a-z0-9\-]+)|^(release\/[0-9]+\.[0-9]+\.[0-9]+)$'
+          ignore: |
+            master
+            main
+            develop
+          min_length: 8
+          max_length: 60

--- a/.github/workflows/deploy_main.yml
+++ b/.github/workflows/deploy_main.yml
@@ -1,0 +1,22 @@
+name: Deploy to Vercel
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v20
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }} # seu token da Vercel
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }} # ID da sua organização
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }} # ID do projeto
+          working-directory: ./
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to improve repository management and deployment processes. The first workflow enforces a consistent branch naming convention for pull requests, and the second automates deployment to Vercel whenever changes are pushed to the `main` branch.

**Repository management improvements:**

* Added `.github/workflows/conventional_branch.yml` to enforce branch naming conventions for pull requests targeting `main`, `develop`, or `master` branches, using a regex pattern and length constraints.

**Deployment automation:**

* Added `.github/workflows/deploy_main.yml` to automatically deploy the project to Vercel on every push to the `main` branch, utilizing organization and project secrets for authentication.